### PR TITLE
Added just working Test::Unit::CoreAssertions#diff

### DIFF
--- a/test/lib/core_assertions.rb
+++ b/test/lib/core_assertions.rb
@@ -635,6 +635,22 @@ eom
           super
         end
       end
+
+      def diff(exp, act)
+        require 'pp'
+        q = PP.new(+"")
+        q.guard_inspect_key do
+          q.group(2, "expected: ") do
+            q.pp exp
+          end
+          q.text q.newline
+          q.group(2, "actual: ") do
+            q.pp act
+          end
+          q.flush
+        end
+        q.output
+      end
     end
   end
 end


### PR DESCRIPTION
This is not "diff", but show expected and actual results both, just to get rid of `NoMethodError` when an assertion failed.