### PR TITLE
Make usable chars more strict

### DIFF
--- a/lib/tmpdir.rb
+++ b/lib/tmpdir.rb
@@ -115,7 +115,7 @@ class Dir
       Dir.tmpdir
     end
 
-    UNUSABLE_CHARS = [File::SEPARATOR, File::ALT_SEPARATOR, File::PATH_SEPARATOR, ":"].uniq.join("").freeze
+    UNUSABLE_CHARS = "^,-.0-9A-Z_a-z~"
 
     class << (RANDOM = Random.new)
       MAX = 36**6 # < 0x100000000

--- a/test/test_tmpdir.rb
+++ b/test/test_tmpdir.rb
@@ -97,8 +97,10 @@ class TestTmpdir < Test::Unit::TestCase
       target = target.chomp('/') + '/'
       traversal_path = target.sub(/\A\w:/, '') # for DOSISH
       traversal_path = Array.new(target.count('/')-2, '..').join('/') + traversal_path
-      actual = yield traversal_path
-      assert_not_send([File.absolute_path(actual), :start_with?, target])
+      [File::SEPARATOR, File::ALT_SEPARATOR].compact.each do |separator|
+        actual = yield traversal_path.tr('/', separator)
+        assert_not_send([File.absolute_path(actual), :start_with?, target])
+      end
     end
   end
 end


### PR DESCRIPTION
Remove other than alphanumeric and some punctuations considered
filesystem-safe, instead of removing some unsafe chars only.

https://hackerone.com/reports/1131465