### PR TITLE
[Bug #18933] Make `Dir.mktmpdir` Ractor-safe

### DIFF
--- a/test/test_tmpdir.rb
+++ b/test/test_tmpdir.rb
@@ -115,4 +115,20 @@ class TestTmpdir < Test::Unit::TestCase
       end
     end
   end
+
+  def test_ractor
+    assert_ractor(<<~'end;', require: "tmpdir")
+      r = Ractor.new do
+        Dir.mktmpdir() do |d|
+          Ractor.yield d
+          Ractor.receive
+        end
+      end
+      dir = r.take
+      assert_file.directory? dir
+      r.send true
+      r.take
+      assert_file.not_exist? dir
+    end;
+  end
 end


### PR DESCRIPTION
Fix https://bugs.ruby-lang.org/issues/18933