### PR TITLE
Document require inside each method on Dir

### DIFF
--- a/lib/tmpdir.rb
+++ b/lib/tmpdir.rb
@@ -22,6 +22,9 @@ class Dir
 
   ##
   # Returns the operating system's temporary file path.
+  #
+  #   require 'tmpdir'
+  #   Dir.tmpdir # => "/tmp"
 
   def self.tmpdir
     ['TMPDIR', 'TMP', 'TEMP', ['system temporary path', SYSTMPDIR], ['/tmp']*2, ['.']*2].find do |name, dir|
@@ -44,6 +47,11 @@ class Dir
   end
 
   # Dir.mktmpdir creates a temporary directory.
+  #
+  #   require 'tmpdir'
+  #   Dir.mktmpdir {|dir|
+  #     # use the directory
+  #   }
   #
   # The directory is created with 0700 permission.
   # Application should not change the permission to make the temporary directory accessible from other users.


### PR DESCRIPTION
It's not obvious when looking at generated documentation for `Dir` that you need to require another file first to expose these methods.