### PR TITLE
Use `IO.popen` to list files

### DIFF
--- a/tmpdir.gemspec
+++ b/tmpdir.gemspec
@@ -15,9 +15,10 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(__dir__) do
-    `git ls-files -z 2>#{IO::NULL}`.split("\x0").reject do |f|
-      (File.expand_path(f) == __FILE__) ||
+  gemspec = File.basename(__FILE__)
+  spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
+    ls.readlines("\x0", chomp: true).reject do |f|
+      (f == gemspec) ||
         f.start_with?(*%w[bin/ test/ spec/ features/ .git Gemfile])
     end
   end


### PR DESCRIPTION
- Redirect `git ls-files` without shelling out.

- When building by `gem`, `__FILE__` is the path name given in the command line, or the gemspec file name in the current directory.  In that case, comparison it and expanded path never equal.  Compare listed file names with the base name of `__FILE__` instead.