### PR TITLE
Fix 1 — Sticky bit check bypass (lines 48-58 and 128-132)

### DIFF
--- a/lib/tmpdir.rb
+++ b/lib/tmpdir.rb
@@ -22,6 +22,18 @@ class Dir
   #   require 'tmpdir'
   #   Dir.tmpdir # => "/tmp"
 
+  # Returns whether world-writable directories without the sticky bit
+  # should be allowed as temporary directories.
+  # Set +RUBY_TMPDIR_ALLOW_WORLD_WRITABLE+ environment variable to
+  # <code>1</code>, <code>true</code>, or <code>yes</code> to allow.
+  # This is useful in container environments (e.g. Kubernetes with
+  # emptyDir volumes) where temporary directories are mounted with
+  # mode 0777 without the sticky bit.
+  def self.allow_world_writable?
+    /\A(1|true|yes)\z/i.match?(ENV["RUBY_TMPDIR_ALLOW_WORLD_WRITABLE"])
+  end
+  private_class_method :allow_world_writable?
+
   def self.tmpdir
     Tmpname::TMPDIR_CANDIDATES.find do |name, dir|
       unless dir
@@ -37,6 +49,9 @@ class Dir
         # writable just from stat; OS mechanisms other than user/group/world bits can affect this.
         warn "#{name} is not writable: #{dir}"
       when stat.world_writable? && !stat.sticky?
+        if allow_world_writable?
+          break dir
+        end
         warn "#{name} is world-writable: #{dir}"
       else
         break dir
@@ -104,7 +119,7 @@ class Dir
       begin
         yield path.dup
       ensure
-        unless base
+        unless base or allow_world_writable?
           base = File.dirname(path)
           stat = File.stat(base)
           if stat.world_writable? and !stat.sticky?

--- a/test/test_tmpdir.rb
+++ b/test/test_tmpdir.rb
@@ -47,6 +47,50 @@ class TestTmpdir < Test::Unit::TestCase
     end
   end
 
+  def test_world_writable_allowed_by_env
+    omit "no meaning on this platform" if /mswin|mingw/ =~ RUBY_PLATFORM
+    Dir.mktmpdir do |tmpdir|
+      envs = %w[TMPDIR TMP TEMP]
+      oldenv = envs.each_with_object({}) {|v, h| h[v] = ENV.delete(v)}
+      old_allow = ENV["RUBY_TMPDIR_ALLOW_WORLD_WRITABLE"]
+      begin
+        ENV[envs[0]] = tmpdir
+        File.chmod(0777, tmpdir)
+
+        # Without env var, world-writable without sticky should be rejected
+        ENV["RUBY_TMPDIR_ALLOW_WORLD_WRITABLE"] = nil
+        assert_not_equal(tmpdir, assert_warn(/world-writable/) {Dir.tmpdir})
+
+        # With env var set, world-writable without sticky should be accepted
+        ENV["RUBY_TMPDIR_ALLOW_WORLD_WRITABLE"] = "1"
+        assert_equal(tmpdir, Dir.tmpdir)
+
+        # mktmpdir should also work
+        newdir = Dir.mktmpdir("d", tmpdir) do |dir|
+          assert_file.directory? dir
+          assert_equal(tmpdir, File.dirname(dir))
+          dir
+        end
+        assert_file.not_exist?(newdir)
+
+        # Other accepted values
+        %w[true yes TRUE Yes].each do |val|
+          ENV["RUBY_TMPDIR_ALLOW_WORLD_WRITABLE"] = val
+          assert_equal(tmpdir, Dir.tmpdir, "should accept with value #{val.inspect}")
+        end
+
+        # Invalid values should not bypass
+        %w[0 false no 2 enabled].each do |val|
+          ENV["RUBY_TMPDIR_ALLOW_WORLD_WRITABLE"] = val
+          assert_not_equal(tmpdir, Dir.tmpdir, "should reject with value #{val.inspect}")
+        end
+      ensure
+        ENV["RUBY_TMPDIR_ALLOW_WORLD_WRITABLE"] = old_allow
+        ENV.update(oldenv)
+      end
+    end
+  end
+
   def test_tmpdir_not_empty_parent
     Dir.mktmpdir do |tmpdir|
       envs = %w[TMPDIR TMP TEMP]


### PR DESCRIPTION
reference : https://github.com/rails/rails/issues/56997

**FIX 1** 

⏺ Summary                                                                                                                                                           
                                                                                                                                                                    
  Context                                                                                                                                                           
                                                                                                                                                                    
  The PR #67 on ruby/tmpdir received feedback from maintainer @rhenium requesting to split it into two separate PRs:                                                
  - Fix 1 — Sticky bit check bypass (configurable via environment variable)                                                                                         
  - Fix 2 — Writability fallback (using stat.writable? when File.writable? fails)                                                                                   
                                                                                                                                                                    
  What was done                                                                                                                                                     
                                                                                                                                                                    
  Extracted Fix 1 only into the local branch fix_first_tmpdir:                                                                                                      
                                                                                                                                                                    
  lib/tmpdir.rb:                                                                                                                                                    
  - Added allow_world_writable? private method that checks the RUBY_TMPDIR_ALLOW_WORLD_WRITABLE environment variable (accepts 1, true, or yes)                      
  - Modified Dir.tmpdir to accept world-writable directories without sticky bit when the env var is set                                                             
  - Modified Dir.mktmpdir to bypass the security check when the env var is set                                                                                      
                                                                                                                                                                    
  test/test_tmpdir.rb:                                                                                                                                              
  - Added test_world_writable_allowed_by_env test case covering:                                                                                                    
    - Default behavior (rejection without env var)                                                                                                                  
    - Acceptance with env var set to valid values (1, true, yes, TRUE, Yes)                                                                                         
    - Rejection with invalid values (0, false, no, 2, enabled)                                                                                                      
    - mktmpdir working correctly with the env var                                                                                                                   
                                                                                                                                                                    
  Test results                                                                                                                                                      
                                                                                                                                                                    
  All 11 tests pass with 60 assertions (100% passed).  

