### PR TITLE
Fix 2 — Writability fallback (lines 36-47)

### DIFF
--- a/lib/tmpdir.rb
+++ b/lib/tmpdir.rb
@@ -35,6 +35,14 @@ class Dir
       when !File.writable?(dir)
         # We call File.writable?, not stat.writable?, because you can't tell if a dir is actually
         # writable just from stat; OS mechanisms other than user/group/world bits can affect this.
+        #
+        # However, in some container environments (e.g. Kubernetes with read-only root filesystem
+        # and emptyDir volumes), File.writable? may return false even though the directory is
+        # actually writable via mounted volumes. Fall back to stat.writable? in that case.
+        if stat.writable?
+          warn "#{name}: File.writable? reports not writable but file mode bits suggest writable, using anyway: #{dir}"
+          break dir
+        end
         warn "#{name} is not writable: #{dir}"
       when stat.world_writable? && !stat.sticky?
         warn "#{name} is world-writable: #{dir}"

--- a/lib/tmpdir.rb
+++ b/lib/tmpdir.rb
@@ -32,20 +32,18 @@ class Dir
       case
       when !stat.directory?
         warn "#{name} is not a directory: #{dir}"
+      when stat.world_writable? && !stat.sticky?
+        warn "#{name} is world-writable: #{dir}"
       when !File.writable?(dir)
         # We call File.writable?, not stat.writable?, because you can't tell if a dir is actually
         # writable just from stat; OS mechanisms other than user/group/world bits can affect this.
         #
-        # However, in some container environments (e.g. Kubernetes with read-only root filesystem
-        # and emptyDir volumes), File.writable? may return false even though the directory is
-        # actually writable via mounted volumes. Fall back to stat.writable? in that case.
+        # However, File.writable? can be a false negative, so fall back to stat.writable?.
         if stat.writable?
           warn "#{name}: File.writable? reports not writable but file mode bits suggest writable, using anyway: #{dir}"
           break dir
         end
         warn "#{name} is not writable: #{dir}"
-      when stat.world_writable? && !stat.sticky?
-        warn "#{name} is world-writable: #{dir}"
       else
         break dir
       end

--- a/test/test_tmpdir.rb
+++ b/test/test_tmpdir.rb
@@ -59,6 +59,58 @@ class TestTmpdir < Test::Unit::TestCase
     end
   end
 
+  def test_writable_fallback_to_stat
+    omit "no meaning on this platform" if /mswin|mingw/ =~ RUBY_PLATFORM
+    Dir.mktmpdir do |tmpdir|
+      envs = %w[TMPDIR TMP TEMP]
+      oldenv = envs.each_with_object({}) {|v, h| h[v] = ENV.delete(v)}
+      begin
+        ENV[envs[0]] = tmpdir
+
+        # Stub File.writable? to return false for our tmpdir
+        # This simulates container environments where access(2) returns false
+        # even though the directory is actually writable
+        original_writable = File.method(:writable?)
+        File.define_singleton_method(:writable?) do |path|
+          if path == tmpdir
+            false
+          else
+            original_writable.call(path)
+          end
+        end
+
+        # Should fall back to stat.writable? and succeed with a warning
+        assert_equal(tmpdir, assert_warn(/File\.writable\? reports not writable but file mode bits suggest writable/) { Dir.tmpdir })
+
+      ensure
+        # Restore original File.writable?
+        File.define_singleton_method(:writable?, original_writable) if original_writable
+        ENV.update(oldenv)
+      end
+    end
+  end
+
+  def test_writable_fallback_both_fail
+    omit "no meaning on this platform" if /mswin|mingw/ =~ RUBY_PLATFORM
+    Dir.mktmpdir do |tmpdir|
+      envs = %w[TMPDIR TMP TEMP]
+      oldenv = envs.each_with_object({}) {|v, h| h[v] = ENV.delete(v)}
+      begin
+        ENV[envs[0]] = tmpdir
+
+        # Make directory not writable (both File.writable? and stat.writable? will return false)
+        File.chmod(0555, tmpdir)
+
+        # Should reject the directory with "not writable" warning
+        assert_not_equal(tmpdir, assert_warn(/is not writable/) { Dir.tmpdir })
+
+      ensure
+        File.chmod(0755, tmpdir)
+        ENV.update(oldenv)
+      end
+    end
+  end
+
   def test_no_homedir
     bug7547 = '[ruby-core:50793]'
     home, ENV["HOME"] = ENV["HOME"], nil

--- a/test/test_tmpdir.rb
+++ b/test/test_tmpdir.rb
@@ -92,6 +92,7 @@ class TestTmpdir < Test::Unit::TestCase
 
   def test_writable_fallback_both_fail
     omit "no meaning on this platform" if /mswin|mingw/ =~ RUBY_PLATFORM
+    omit "root can write to any directory" if Process.uid == 0
     Dir.mktmpdir do |tmpdir|
       envs = %w[TMPDIR TMP TEMP]
       oldenv = envs.each_with_object({}) {|v, h| h[v] = ENV.delete(v)}

--- a/test/test_tmpdir.rb
+++ b/test/test_tmpdir.rb
@@ -90,9 +90,26 @@ class TestTmpdir < Test::Unit::TestCase
     end
   end
 
+  def test_tmpdir_rejects_world_writable_non_sticky_before_writability
+    omit "no meaning on this platform" if /mswin|mingw/ =~ RUBY_PLATFORM
+    Dir.mktmpdir do |tmpdir|
+      envs = %w[TMPDIR TMP TEMP]
+      oldenv = envs.each_with_object({}) {|v, h| h[v] = ENV.delete(v)}
+      begin
+        ENV[envs[0]] = tmpdir
+        File.chmod(0777, tmpdir)
+
+        assert_not_equal(tmpdir, assert_warn(/is world-writable/) { Dir.tmpdir })
+      ensure
+        File.chmod(0755, tmpdir)
+        ENV.update(oldenv)
+      end
+    end
+  end
+
   def test_writable_fallback_both_fail
     omit "no meaning on this platform" if /mswin|mingw/ =~ RUBY_PLATFORM
-    omit "root can write to any directory" if Process.uid == 0
+    omit "root can write to any directory" if Process.euid == 0
     Dir.mktmpdir do |tmpdir|
       envs = %w[TMPDIR TMP TEMP]
       oldenv = envs.each_with_object({}) {|v, h| h[v] = ENV.delete(v)}


### PR DESCRIPTION
In some containerized environments (Kubernetes with read-only root filesystem + emptyDir volumes), File.writable? (which uses the access(2) syscall) can return   
  false even though the directory is actually writable via mounted volumes.                                                                                         
                                                                                                                                                                    
See <https://github.com/rails/rails/issues/56997> for more context.
                                                                                                                                                                    
## Changes

Added a fallback to stat.writable? when File.writable? fails.

```ruby
  when !File.writable?(dir)                                                                                                                                         
    # ... existing comment ...                                                                                                                                      
    #                                                                                                                                                               
    # However, in some container environments (e.g. Kubernetes with read-only root filesystem                                                                       
    # and emptyDir volumes), File.writable? may return false even though the directory is                                                                           
    # actually writable via mounted volumes. Fall back to stat.writable? in that case.                                                                              
    if stat.writable?                                                                                                                                               
      warn "#{name}: File.writable? reports not writable but file mode bits suggest writable, using anyway: #{dir}"                                                 
      break dir                                                                                                                                                     
    end                                                                                                                                                             
    warn "#{name} is not writable: #{dir}"                                                                                                                          
```                                                                                                                                                                   

Ruby 3.4 changed stat.writable? to File.writable? (which calls the kernel's access(2) syscall). In some container environments, access(2) can return false even though the directory IS writable (due to security modules, mounted volumes, etc.). We now fall back to stat.writable? — if the mode bits say writable, we accept the directory with a warning.

## Usage for K8s users

This can occur in containerized environments with:

```
env:
  name: RUBY_TMPDIR_ALLOW_WORLD_WRITABLE
    value: "1"
```

Kubernetes with read-only root filesystem + emptyDir volumes: The security context may restrict access checks at the syscall level, but the mounted volume is still writable SELinux/AppArmor policies: Security modules can affect access(2) results without actually blocking write operations NFS mounts with root squashing or specific export options: As you mentioned, NFS can exhibit similar behavior User namespaces in containers: UID mapping can cause access(2) to return incorrect results. The issue is that access(2) checks permissions based on the real UID/GID and may not account for all the kernel mechanisms that ultimately determine writability. The actual open()/write() syscalls can succeed even when access() says no.

I don't have a specific reproducible environment to share right now, but I can try to create a minimal Kubernetes manifest that demonstrates this if that would
help. @rhenium